### PR TITLE
Lower memset and memcpy to 8051 for performance

### DIFF
--- a/examples/c/main.c
+++ b/examples/c/main.c
@@ -25,6 +25,7 @@ volatile uint32_t nonzero_initialized = 0x12345678;
 
 static uint8_t volatile * const sbuf = (uint8_t volatile *)0xC0000099;
 
+#define SYS_memcpy 1024
 #define SYS_memset 1025
 static uintptr_t syscall(uintptr_t which, uint32_t arg0, uint32_t arg1, uint32_t arg2)
 {
@@ -40,15 +41,12 @@ static uintptr_t syscall(uintptr_t which, uint32_t arg0, uint32_t arg1, uint32_t
 
 
 void * memcpy (void * destination, void const * source, size_t num) {
-	for (size_t i = 0; i < num; i++)
-		((uint8_t *)destination)[i] = ((uint8_t *)source)[i];
-
-	return destination;
+	/* use system call */
+	return (void*)syscall(SYS_memcpy, (uintptr_t)destination, (uintptr_t)source, num);
 }
 
 void * memset (void * ptr, int value, size_t num) {
-	/* use system call */
-	return (void*)syscall(SYS_memset, ptr, value, num);
+	return (void*)syscall(SYS_memset, (uintptr_t)ptr, value, num);
 }
 
 static void putchar(char c) {

--- a/examples/c/main.c
+++ b/examples/c/main.c
@@ -25,6 +25,20 @@ volatile uint32_t nonzero_initialized = 0x12345678;
 
 static uint8_t volatile * const sbuf = (uint8_t volatile *)0xC0000099;
 
+#define SYS_memset 1025
+static uintptr_t syscall(uintptr_t which, uint32_t arg0, uint32_t arg1, uint32_t arg2)
+{
+        register uint32_t a7 asm ("a7") = which;
+        register uint32_t a0 asm ("a0") = arg0;
+        register uint32_t a1 asm ("a1") = arg1;
+        register uint32_t a2 asm ("a2") = arg2;
+
+        asm volatile("ecall" :: "r"(a7), "r"(a0), "r"(a1), "r"(a2) );
+        return arg0;
+}
+
+
+
 void * memcpy (void * destination, void const * source, size_t num) {
 	for (size_t i = 0; i < num; i++)
 		((uint8_t *)destination)[i] = ((uint8_t *)source)[i];
@@ -33,10 +47,8 @@ void * memcpy (void * destination, void const * source, size_t num) {
 }
 
 void * memset (void * ptr, int value, size_t num) {
-	for (size_t i = 0; i < num; i++)
-		((uint8_t *)ptr)[i] = (uint8_t)value;
-
-	return ptr;
+	/* use system call */
+	return (void*)syscall(SYS_memset, ptr, value, num);
 }
 
 static void putchar(char c) {

--- a/src/main.S
+++ b/src/main.S
@@ -437,9 +437,9 @@ memcpy_loop:
         xch     a, R5
         ; decrement R7:R6 and continue if non zero
 	djnz    R6, memcpy_loop
-        dec     R7
-        cjne    R7, #0xff, memcpy_loop
-        sjmp    memcpy_ret
+        mov     a, R7
+        jz      memcpy_ret
+        djnz    R7, memcpy_loop
 
 exec_memcpy_romsrc:
         ; adjust DPTR for rv_code
@@ -469,8 +469,9 @@ memcpy_loop_romsrc:
         xch     a, dph
         xch     a, R5
 	djnz    R6, memcpy_loop_romsrc
-        dec     R7
-        cjne    R7, #0xff, memcpy_loop_romsrc
+        mov     a, R7
+        jz      memcpy_ret
+        djnz    R7, memcpy_loop_romsrc
 
 memcpy_ret:
         pop     dpl

--- a/src/main.S
+++ b/src/main.S
@@ -342,39 +342,39 @@ exec_ecall:
 	sjmp	.
 
 exec_ecall_notexit:
-        ;  check syscall for correctness
-        mov     B, a                        ; remember syscall LSB
-        anl     a, #0xfe
-        cpl     a.2                         ; should be 1 now
+	;  check syscall for correctness
+	mov     B, a                        ; remember syscall LSB
+	anl     a, #0xfe
+	cpl     a.2                         ; should be 1 now
 	mov	R1, #(rv_x0 + (4 * 17) + 1) ; MSB of syscall number
 	xrl	a, @R1                      ; a.2 should be 0 now
-        jz      syscall_OK
-        ljmp    exec_ecall_exception ; MSB !=4 or LSB > 1
+	jz      syscall_OK
+	ljmp    exec_ecall_exception ; MSB !=4 or LSB > 1
 
 syscall_OK:
-        ; check destination address space
+	; check destination address space
 	mov     R1, #(rv_x0 + (4 * 10) + 3) ; high byte of dst (a0)
 	mov     a, @R1
 	jnb     a.7, dest_OK  ; read-only or SFR memory
-        ret
+	ret
 dest_OK:
 	mov     R1, #(rv_x0 + (4 * 12)) ; LSB of count (a2) = 3rd param (n)
 	mov     (0 + 6), @R1            ; set into R6 direct (we don't use banks)
 	inc     R1
 	mov     (0 + 7), @R1            ; R7 = MSB of count
-        mov     a, R6
-        orl     a, R7
-        jnz     not_empty
-        ret                             ; nothing to do
+	mov     a, R6
+	orl     a, R7
+	jnz     not_empty
+	ret                             ; nothing to do
 
 not_empty:
-        push    dph
-        push    dpl
+	push    dph
+	push    dpl
 
-        jnb     B.0, exec_ecall_memcpy
+	jnb     B.0, exec_ecall_memcpy
 
 exec_ecall_memset:
-        ; get dest address into DPTR
+	; get dest address into DPTR
 	mov     R1, #(rv_x0 + (4 * 10) + 1) ; byte 1 of dst (a0)
 	mov     dph, @R1         ; MSB of dst
 	dec     R1
@@ -382,7 +382,7 @@ exec_ecall_memset:
 
 	; get the value to set
 	mov     R1, #(rv_x0 + (4 * 11)) ; low byte of a1 = 2nd param (c)
-        mov     a, @R1
+	mov     a, @R1
 
 memset_loop:
 	movx    @DPTR, a
@@ -392,91 +392,91 @@ memset_loop:
 	dec     R7
 	cjne    R7, #0xff, memset_loop
 
-        sjmp    memcpy_ret
+	sjmp    memcpy_ret
 
 exec_ecall_memcpy:
-        ; get dest address into R5:R4
+	; get dest address into R5:R4
 	mov     R1, #(rv_x0 + (4 * 10) + 1) ; byte 1 of dst (a0)
 	mov     (0 + 5), @R1
 	dec     R1
 	mov     (0 + 4), @R1
 
-        ; get source address
+	; get source address
 	mov     R1, #(rv_x0 + (4 * 11) + 3) ; high byte of src (a1)
 	mov     a, @R1
 
-        dec     R1
-        dec     R1
-        mov     dph, @R1    ; MSB of source address
-        dec     R1
-        mov     dpl, @R1    ; MSB of source address
+	dec     R1
+	dec     R1
+	mov     dph, @R1    ; MSB of source address
+	dec     R1
+	mov     dpl, @R1    ; MSB of source address
 
 	; check the source address space
 	jnb     a.6, not_sfr  ; ignore SFR memory, for now
-        sjmp    memcpy_ret
+	sjmp    memcpy_ret
 not_sfr:
-        jb      a.7, exec_memcpy_romsrc
+	jb      a.7, exec_memcpy_romsrc
 
 memcpy_loop:
 	movx    a, @DPTR
-        inc     DPTR
-        ; switch dph/dpl with R5/R4
-        xch     a, R4
-        xch     a, dpl
-        xch     a, R4
-        xch     a, R5
-        xch     a, dph
-        xch     a, R5
+	inc     DPTR
+	; switch dph/dpl with R5/R4
+	xch     a, R4
+	xch     a, dpl
+	xch     a, R4
+	xch     a, R5
+	xch     a, dph
+	xch     a, R5
 	movx    @DPTR, a
 	inc     DPTR
-        xch     a, R4
-        xch     a, dpl
-        xch     a, R4
-        xch     a, R5
-        xch     a, dph
-        xch     a, R5
-        ; decrement R7:R6 and continue if non zero
+	xch     a, R4
+	xch     a, dpl
+	xch     a, R4
+	xch     a, R5
+	xch     a, dph
+	xch     a, R5
+	; decrement R7:R6 and continue if non zero
 	djnz    R6, memcpy_loop
-        mov     a, R7
-        jz      memcpy_ret
-        djnz    R7, memcpy_loop
+	mov     a, R7
+	jz      memcpy_ret
+	djnz    R7, memcpy_loop
 
 exec_memcpy_romsrc:
-        ; adjust DPTR for rv_code
-        mov     a, dpl
-        add     a, #(rv_code)
-        mov     dpl, a
-        mov     a, dph
-        addc    a, #(rv_code >> 8)
-        mov     dph, a
+	; adjust DPTR for rv_code
+	mov     a, dpl
+	add     a, #(rv_code)
+	mov     dpl, a
+	mov     a, dph
+	addc    a, #(rv_code >> 8)
+	mov     dph, a
 
 memcpy_loop_romsrc:
-        clr     a
+	clr     a
 	movc    a, @a+DPTR
-        inc     DPTR
-        xch     a, R4
-        xch     a, dpl
-        xch     a, R4
-        xch     a, R5
-        xch     a, dph
-        xch     a, R5
+	inc     DPTR
+	xch     a, R4
+	xch     a, dpl
+	xch     a, R4
+	xch     a, R5
+	xch     a, dph
+	xch     a, R5
 	movx    @DPTR, a
 	inc     DPTR
-        xch     a, R4
-        xch     a, dpl
-        xch     a, R4
-        xch     a, R5
-        xch     a, dph
-        xch     a, R5
+	xch     a, R4
+	xch     a, dpl
+	xch     a, R4
+	xch     a, R5
+	xch     a, dph
+	xch     a, R5
 	djnz    R6, memcpy_loop_romsrc
-        mov     a, R7
-        jz      memcpy_ret
-        djnz    R7, memcpy_loop_romsrc
+	mov     a, R7
+	jz      memcpy_ret
+	djnz    R7, memcpy_loop_romsrc
 
 memcpy_ret:
-        pop     dpl
-        pop     dph
-        ret
+	pop     dpl
+	pop     dph
+	ret
 
 exec_ecall_exception:
 	; Save the exception reason ("Environment call from M-mode") in
@@ -1547,7 +1547,7 @@ exec_op_imm_rd_not_zero:
 	; into the low bits.
 	mov	a, funct3
 	rl	a
-        add     a, funct3
+	add     a, funct3
 
 	; Save dptr. Each execution function will need to restore dptr
 	; since they don't return to this function.

--- a/src/main.S
+++ b/src/main.S
@@ -342,39 +342,45 @@ exec_ecall:
 	sjmp	.
 
 exec_ecall_notexit:
-	; there may ultimately be many functions here
-	; for now it's just memset (0x0401)
-	cjne    a, #1, exec_ecall_exception
+        ;  check syscall for correctness
+        mov     B, a                        ; remember syscall LSB
+        anl     a, #0xfe
+        cpl     a.2                         ; should be 1 now
+	mov	R1, #(rv_x0 + (4 * 17) + 1) ; MSB of syscall number
+	xrl	a, @R1                      ; a.2 should be 0 now
+        jz      syscall_OK
+        ljmp    exec_ecall_exception ; MSB !=4 or LSB > 1
 
-	; check MSB
-	inc     R1
-	cjne    @R1, #0x04, exec_ecall_exception
-
-exec_ecall_memset:
-	push    dph
-	push    dpl
-
-	;; check the destination address space
+syscall_OK:
+        ; check destination address space
 	mov     R1, #(rv_x0 + (4 * 10) + 3) ; high byte of dst (a0)
 	mov     a, @R1
-	jb      a.7, memset_ret  ; read-only or SFR memory
-
-	dec     R1
-	dec     R1
-	mov     dph, @R1         ; MSB of dst
-	dec     R1
-	mov     dpl, @R1         ; LSB of dst
-
+	jnb     a.7, dest_OK  ; read-only or SFR memory
+        ret
+dest_OK:
 	mov     R1, #(rv_x0 + (4 * 12)) ; LSB of count (a2) = 3rd param (n)
 	mov     (0 + 6), @R1            ; set into R6 direct (we don't use banks)
 	inc     R1
 	mov     (0 + 7), @R1            ; R7 = MSB of count
+        mov     a, R6
+        orl     a, R7
+        jnz     not_empty
+        ret                             ; nothing to do
 
-	;; terminate early if 0 bytes to copy
-	orl     a, R6
-	jz      memset_ret
+not_empty:
+        push    dph
+        push    dpl
 
-	;; get the value to set
+        jnb     B.0, exec_ecall_memcpy
+
+exec_ecall_memset:
+        ; get dest address into DPTR
+	mov     R1, #(rv_x0 + (4 * 10) + 1) ; byte 1 of dst (a0)
+	mov     dph, @R1         ; MSB of dst
+	dec     R1
+	mov     dpl, @R1         ; LSB of dst
+
+	; get the value to set
 	mov     R1, #(rv_x0 + (4 * 11)) ; low byte of a1 = 2nd param (c)
         mov     a, @R1
 
@@ -382,14 +388,94 @@ memset_loop:
 	movx    @DPTR, a
 	inc     DPTR
 	djnz    R6, memset_loop
-	;; inner 256b loop has terminated, restart if R7 nonzero
+	; inner 256b loop has terminated, restart if R7 nonzero
 	dec     R7
 	cjne    R7, #0xff, memset_loop
 
-memset_ret:
-	pop     dpl
-	pop     dph
-	ret
+        sjmp    memcpy_ret
+
+exec_ecall_memcpy:
+        ; get dest address into R5:R4
+	mov     R1, #(rv_x0 + (4 * 10) + 1) ; byte 1 of dst (a0)
+	mov     (0 + 5), @R1
+	dec     R1
+	mov     (0 + 4), @R1
+
+        ; get source address
+	mov     R1, #(rv_x0 + (4 * 11) + 3) ; high byte of src (a1)
+	mov     a, @R1
+
+        dec     R1
+        dec     R1
+        mov     dph, @R1    ; MSB of source address
+        dec     R1
+        mov     dpl, @R1    ; MSB of source address
+
+	; check the source address space
+	jnb     a.6, not_sfr  ; ignore SFR memory, for now
+        sjmp    memcpy_ret
+not_sfr:
+        jb      a.7, exec_memcpy_romsrc
+
+memcpy_loop:
+	movx    a, @DPTR
+        inc     DPTR
+        ; switch dph/dpl with R5/R4
+        xch     a, R4
+        xch     a, dpl
+        xch     a, R4
+        xch     a, R5
+        xch     a, dph
+        xch     a, R5
+	movx    @DPTR, a
+	inc     DPTR
+        xch     a, R4
+        xch     a, dpl
+        xch     a, R4
+        xch     a, R5
+        xch     a, dph
+        xch     a, R5
+        ; decrement R7:R6 and continue if non zero
+	djnz    R6, memcpy_loop
+        dec     R7
+        cjne    R7, #0xff, memcpy_loop
+        sjmp    memcpy_ret
+
+exec_memcpy_romsrc:
+        ; adjust DPTR for rv_code
+        mov     a, dpl
+        add     a, #(rv_code)
+        mov     dpl, a
+        mov     a, dph
+        addc    a, #(rv_code >> 8)
+        mov     dph, a
+
+memcpy_loop_romsrc:
+        clr     a
+	movc    a, @a+DPTR
+        inc     DPTR
+        xch     a, R4
+        xch     a, dpl
+        xch     a, R4
+        xch     a, R5
+        xch     a, dph
+        xch     a, R5
+	movx    @DPTR, a
+	inc     DPTR
+        xch     a, R4
+        xch     a, dpl
+        xch     a, R4
+        xch     a, R5
+        xch     a, dph
+        xch     a, R5
+	djnz    R6, memcpy_loop_romsrc
+        dec     R7
+        cjne    R7, #0xff, memcpy_loop_romsrc
+
+memcpy_ret:
+        pop     dpl
+        pop     dph
+        ret
 
 exec_ecall_exception:
 	; Save the exception reason ("Environment call from M-mode") in

--- a/src/main.S
+++ b/src/main.S
@@ -327,8 +327,8 @@ exec_ecall:
 	mov	R1, #(rv_x0 + (4 * 17))  ; Syscall number is in register a7 (x17).
 	mov	a, @R1
 
-	; Only directly handle the "exit" syscall.
-	cjne	a, #93, exec_ecall_exception
+	; Directly handle the "exit" syscall.
+	cjne	a, #93, exec_ecall_notexit
 
 	mov	R1, #(rv_x0 + (4 * 10))  ; Exit retval is in register a0 (x10).
 	mov	a, @R1
@@ -340,6 +340,56 @@ exec_ecall:
 	; Loop forever so the debugger can see the retval preserved in
 	; the RV registers, too.
 	sjmp	.
+
+exec_ecall_notexit:
+	; there may ultimately be many functions here
+	; for now it's just memset (0x0401)
+	cjne    a, #1, exec_ecall_exception
+
+	; check MSB
+	inc     R1
+	cjne    @R1, #0x04, exec_ecall_exception
+
+exec_ecall_memset:
+	push    dph
+	push    dpl
+
+	;; check the destination address space
+	mov     R1, #(rv_x0 + (4 * 10) + 3) ; high byte of dst (a0)
+	mov     a, @R1
+	jb      a.7, memset_ret  ; read-only or SFR memory
+
+	dec     R1
+	dec     R1
+	mov     dph, @R1         ; MSB of dst
+	dec     R1
+	mov     dpl, @R1         ; LSB of dst
+
+	mov     R1, #(rv_x0 + (4 * 12)) ; LSB of count (a2) = 3rd param (n)
+	mov     (0 + 6), @R1            ; set into R6 direct (we don't use banks)
+	inc     R1
+	mov     (0 + 7), @R1            ; R7 = MSB of count
+
+	;; terminate early if 0 bytes to copy
+	orl     a, R6
+	jz      memset_ret
+
+	;; get the value to set
+	mov     R1, #(rv_x0 + (4 * 11)) ; low byte of a1 = 2nd param (c)
+        mov     a, @R1
+
+memset_loop:
+	movx    @DPTR, a
+	inc     DPTR
+	djnz    R6, memset_loop
+	;; inner 256b loop has terminated, restart if R7 nonzero
+	dec     R7
+	cjne    R7, #0xff, memset_loop
+
+memset_ret:
+	pop     dpl
+	pop     dph
+	ret
 
 exec_ecall_exception:
 	; Save the exception reason ("Environment call from M-mode") in
@@ -1410,6 +1460,7 @@ exec_op_imm_rd_not_zero:
 	; into the low bits.
 	mov	a, funct3
 	rl	a
+        add     a, funct3
 
 	; Save dptr. Each execution function will need to restore dptr
 	; since they don't return to this function.
@@ -1421,13 +1472,13 @@ exec_op_imm_rd_not_zero:
 	jmp	@a+dptr
 
 exec_op_imm_jump_table:
-	ajmp	exec_addi  ; 0, ADDI
-	ajmp	exec_slli  ; 1, SLLI
-	ajmp	exec_slti_sltiu  ; 2, SLTI
-	ajmp	exec_slti_sltiu  ; 3, SLTIU
-	ajmp	exec_xori  ; 4, XORI
-	ajmp	exec_srli_srai  ; 5, SRLI/SRAI
-	ajmp	exec_ori  ; 6, ORI
+	ljmp	exec_addi  ; 0, ADDI
+	ljmp	exec_slli  ; 1, SLLI
+	ljmp	exec_slti_sltiu  ; 2, SLTI
+	ljmp	exec_slti_sltiu  ; 3, SLTIU
+	ljmp	exec_xori  ; 4, XORI
+	ljmp	exec_srli_srai  ; 5, SRLI/SRAI
+	ljmp	exec_ori  ; 6, ORI
 	ljmp	exec_andi  ; 7, ANDI
 
 	; No need for a default case as the value of A is already


### PR DESCRIPTION
The performance of many real world applications is dominated by data movement, and this provides an opportunity to speed rv51 by implementing a few key libc functions at the 8051 level. At the cost of an extra 166 bytes (minus a small improvement in RISCV size) I found some nice speedups:

## RISCV benchmarks

| Benchmark | memcpy/set change | rv51 (s51 ticks) | Speedup |
|--------- |----------------- |---------------- |------- |
| median    | 20799744          | 28880352         | 28.0%   |
| qsort     | 450237564         | 488045772        | 7.7%    |
| rsort     | 834642576         | 884368992        | 5.6%    |
| towers    | 17660928          | 17799816         | 0.8%    |
| vvadd     | 12810540          | 21687048         | 40.9%   |
| multiply  | 83308452          | 86778900         | 4.0%    |


## Applications

| Name            | with new memcpy/memset | without       | Speedup |
|--------------- |---------------------- |------------- |------- |
| C hello world   | 3259980 ticks          | 3324624 ticks | 1.9%    |
| My TinyUSB fork | 13s                    | 20s           | 35.0%   |

## Architecture

I wasn't sure how to properly handle the transition between layers. For now it's a system call. If there is a designated mechanism in RISCV for communicating between code and e.g. a virtual machine that would be a better fit.

I hope this will be interesting upstream; I know I intend to use it in my TinyUSB project where it's very helpful in filling the gap between the speed of sdcc (such as it is) and rv51.