### PR TITLE
Make the number of interrupt vectors configurable

### DIFF
--- a/src/main.S
+++ b/src/main.S
@@ -115,6 +115,7 @@ rv_x0	= 0x80
 .ifndef NUM_INTERRUPTS
 NUM_INTERRUPTS = 5
 .endif
+interrupt_vector = 0x0003
 
 	.area	XSEG	(XDATA)
 	.area	PSEG	(PAG,XDATA)
@@ -123,10 +124,12 @@ NUM_INTERRUPTS = 5
 reset:
 	ljmp	init
 
-	.org	0x0003
+	.org	interrupt_vector
 	.rept	NUM_INTERRUPTS
-	ljmp	common_isr
-	.ds	5              ; pad 3-byte ljmp out to the 8-byte vector slot
+	setb	misc_bit0__new_interrupt
+	reti
+interrupt_vector = interrupt_vector + 8
+	.org	interrupt_vector
 	.endm
 
 	sjmp	.
@@ -3985,10 +3988,6 @@ interrupt_controller:
 1$:
 	; Not vectored or not asynchronous.
 	ret
-
-isr_common:
-	setb	misc_bit0__new_interrupt
-	reti
 
 emulator_size:
 	; The size of the emulator, in bytes, as a little-endian 32-bit

--- a/src/main.S
+++ b/src/main.S
@@ -112,6 +112,10 @@ rv_csr_mscratch_3 = 0x4B
 stack_base = 0x4C
 rv_x0	= 0x80
 
+.ifndef NUM_INTERRUPTS
+NUM_INTERRUPTS = 5
+.endif
+
 	.area	XSEG	(XDATA)
 	.area	PSEG	(PAG,XDATA)
 	.area	HOME	(ABS,CODE)
@@ -120,19 +124,10 @@ reset:
 	ljmp	init
 
 	.org	0x0003
-	ljmp	isr_eint0
-
-	.org	0x000b
-	ljmp	isr_timer0
-
-	.org	0x0013
-	ljmp	isr_eint1
-
-	.org	0x001b
-	ljmp	isr_timer1
-
-	.org	0x0023
-	ljmp	isr_serial
+	.rept	NUM_INTERRUPTS
+	ljmp	common_isr
+	.ds	5              ; pad 3-byte ljmp out to the 8-byte vector slot
+	.endm
 
 	sjmp	.
 
@@ -3991,23 +3986,7 @@ interrupt_controller:
 	; Not vectored or not asynchronous.
 	ret
 
-isr_eint0:
-	setb	misc_bit0__new_interrupt
-	reti
-
-isr_eint1:
-	setb	misc_bit0__new_interrupt
-	reti
-
-isr_timer0:
-	setb	misc_bit0__new_interrupt
-	reti
-
-isr_timer1:
-	setb	misc_bit0__new_interrupt
-	reti
-
-isr_serial:
+isr_common:
 	setb	misc_bit0__new_interrupt
 	reti
 


### PR DESCRIPTION
Some modern 8051 microcontrollers have a lot of ISRs. STC8H8K64U for example has 28. Hopefully this PR should be a simple enough one that isn't intrusive at all.
Would be an interesting idea to see if this allows porting of libraries like TinyUSB to it.

